### PR TITLE
Fix for inheritance without ending colon

### DIFF
--- a/grammars/stanza.cson
+++ b/grammars/stanza.cson
@@ -30,7 +30,7 @@ patterns: [
         begin: "(<:)"
         beginCaptures:
           0: name: "keyword.operator.parent.stanza"
-        end: "(?=:)"
+        end: "\\s*$|(?=[:;])"
         contentName: "entity.other.inherited-class.stanza"
         patterns: [
           {


### PR DESCRIPTION
Wasn't checking for line endings inside the inheritance rule.
